### PR TITLE
infra(jslab): default-deny netpol + egress lockdown, trace probes, security-headers middleware

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -23,31 +23,62 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up SSH
+      - name: Setup SSH (known_hosts + key)
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+          SSH_FINGERPRINT: ${{ secrets.SSH_FINGERPRINT }}
         run: |
           set -euo pipefail
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_KEY_B64 }}" | base64 -d > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keygen -y -f ~/.ssh/id_ed25519 >/dev/null
-          ssh-keyscan -H 178.105.195.93 >> ~/.ssh/known_hosts
 
-      - name: Test SSH
-        run: |
-          set -euo pipefail
-          ssh -i ~/.ssh/id_ed25519 \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
-            root@178.105.195.93 "echo ok"
+          mkdir -p ~/.ssh
+          key_path="$HOME/.ssh/id_deploy"
+          raw_tmp="$(mktemp)"
+          b64_tmp="$(mktemp)"
+          trap 'rm -f "${raw_tmp}" "${b64_tmp}"' EXIT
+
+          # Accept both raw multi-line keys and base64-encoded keys.
+          printf '%s\n' "${SSH_KEY}" | tr -d '\r' > "${raw_tmp}"
+          if ssh-keygen -y -f "${raw_tmp}" </dev/null >/dev/null 2>&1; then
+            mv "${raw_tmp}" "${key_path}"
+          elif printf '%s' "${SSH_KEY}" | base64 --decode 2>/dev/null | tr -d '\r' > "${b64_tmp}" \
+            && ssh-keygen -y -f "${b64_tmp}" </dev/null >/dev/null 2>&1; then
+            mv "${b64_tmp}" "${key_path}"
+          else
+            echo "SSH_KEY secret is not a valid private key (raw PEM/OpenSSH or base64-encoded)." >&2
+            exit 1
+          fi
+          chmod 600 "${key_path}"
+
+          hostkeys="$(mktemp)"
+          ssh-keyscan -p "${SSH_PORT}" -H "${SSH_HOST}" > "${hostkeys}" 2>/dev/null
+
+          if [ -n "${SSH_FINGERPRINT:-}" ]; then
+            if ! ssh-keygen -lf "${hostkeys}" | grep -Fq "${SSH_FINGERPRINT}"; then
+              echo "SSH host key fingerprint mismatch for ${SSH_HOST}." >&2
+              ssh-keygen -lf "${hostkeys}" >&2 || true
+              exit 1
+            fi
+          fi
+
+          cat "${hostkeys}" >> ~/.ssh/known_hosts
+          rm -f "${hostkeys}"
 
       - name: Deploy
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
         run: |
           set -euo pipefail
 
-          ssh -i ~/.ssh/id_ed25519 \
+          ssh -i ~/.ssh/id_deploy \
+            -o BatchMode=yes \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
-            root@178.105.195.93 <<'EOSSH'
+            -p "${SSH_PORT}" \
+            "${SSH_USER}@${SSH_HOST}" <<'EOSSH'
           set -euo pipefail
 
           cd /root/js-engines

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,52 @@
+# infra
+
+Kustomize manifests for the `jslab` namespace on k3s (Traefik ingress).
+
+## Layout
+
+- `k8s/base/` — full stack (deployments, services, configmap, ingress, middleware, networkpolicy).
+- `k8s/prod/` — `../base` + image tag overrides. CI rewrites tags to the commit SHA.
+  - `k8s/prod/services/<svc>/` — single-service slice; each per-service deploy
+    workflow renders only its own slice (`--load-restrictor LoadRestrictionsNone`).
+- `k8s/dev/` — Skaffold overlay. Intentionally excludes Traefik CRDs
+  (Ingress / Middleware) and NetworkPolicies; use port-forward locally.
+- `policy/ingress.rego` — Conftest/OPA check for ingress host/path collisions
+  and dangling TLS secret references.
+
+## Network policy model
+
+`networkpolicy.yaml` is **default-deny ingress + egress** for the whole
+namespace, with additive allowlists:
+
+- DNS (port 53 → kube-system) is allowed for every pod.
+- Ingress: traefik→frontend, {traefik,frontend}→api, {api,frontend}→trace-service,
+  api→each engine, api→redis.
+- Egress: api→engines+trace+redis, frontend→api+trace.
+- **Engines and trace-service get no egress allow** (DNS only). They execute
+  untrusted JS, so default-deny keeps a malicious snippet from making outbound
+  calls. Do not add broad egress to these pods.
+
+## Secrets / certs (provisioned out-of-band, not in git)
+
+These exist on the cluster and are **not** committed:
+
+- `jslab-su-origin-tls`, `jslab-cc-origin-tls` — Cloudflare Origin certificates
+  (CF set to Full (strict)). Referenced by `ingress.yaml` `tls:`. Recreate with
+  `kubectl -n jslab create secret tls <name> --cert=... --key=...`.
+
+`middleware.yaml` (`jslab-security-headers`) is now tracked in git. If a copy was
+previously applied by hand, diff before letting CI apply so a tuned config is not
+overwritten:
+
+```
+kubectl -n jslab get middleware jslab-security-headers -o yaml
+```
+
+## Deploy
+
+- `deploy-infra.yml` — pushes to `infra/**` SSH to the VPS and
+  `kubectl apply -k` the prod overlay (host/user/fingerprint via secrets).
+- `reusable-deploy-service-vps.yml` — per-service build + push + single-slice apply.
+
+> Note: deploys use `kubectl apply` without `--prune`; resources removed from
+> manifests must be deleted from the cluster by hand.

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - engine-jsc.yaml
   - engine-spidermonkey.yaml
   - frontend.yaml
+  - middleware.yaml
   - ingress.yaml
   - networkpolicy.yaml

--- a/infra/k8s/base/middleware.yaml
+++ b/infra/k8s/base/middleware.yaml
@@ -1,0 +1,30 @@
+# Security-headers middleware referenced by all ingresses as
+#   traefik.ingress.kubernetes.io/router.middlewares: jslab-jslab-security-headers@kubernetescrd
+# (namespace "jslab" + name "jslab-security-headers").
+#
+# RECONCILE BEFORE FIRST APPLY: if a middleware of this name already
+# exists on the cluster (it was previously applied out-of-band), diff it
+#   kubectl -n jslab get middleware jslab-security-headers -o yaml
+# against this file so CI does not clobber a tuned config. CSP is left
+# out on purpose — add one only after verifying it against the app.
+#
+# apiVersion is Traefik v3 (traefik.io). For Traefik v2 use
+# traefik.containo.us/v1alpha1.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: jslab-security-headers
+  namespace: jslab
+spec:
+  headers:
+    contentTypeNosniff: true
+    frameDeny: true
+    browserXssFilter: true
+    referrerPolicy: strict-origin-when-cross-origin
+    stsSeconds: 63072000
+    stsIncludeSubdomains: true
+    stsPreload: true
+    forceSTSHeader: true
+    customResponseHeaders:
+      Permissions-Policy: "geolocation=(), microphone=(), camera=()"
+      X-Permitted-Cross-Domain-Policies: "none"

--- a/infra/k8s/base/networkpolicy.yaml
+++ b/infra/k8s/base/networkpolicy.yaml
@@ -1,3 +1,64 @@
+# ─────────────────────────────────────────────────────────────
+# Default deny (ingress + egress) for every pod in the namespace.
+# Everything below is an additive allowlist on top of this.
+# Probe replies are permitted: NetworkPolicy is stateful, so the
+# response to an allowed inbound kubelet probe is not blocked by
+# the egress deny.
+# ─────────────────────────────────────────────────────────────
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+# DNS egress for all pods (CoreDNS lives in kube-system).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+# ─────────────────────────────────────────────────────────────
+# Ingress allowlists
+# ─────────────────────────────────────────────────────────────
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: frontend-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: frontend
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 3000
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -16,6 +77,30 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/name: traefik
+        - podSelector:
+            matchLabels:
+              app: frontend
+      ports:
+        - port: 8080
+---
+# trace-service is reached by both the API gateway and the frontend
+# (SSR initial data). It runs engine262 over untrusted input, so lock
+# its sources and (via default-deny) its egress.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trace-service-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: trace-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: api
         - podSelector:
             matchLabels:
               app: frontend
@@ -111,3 +196,65 @@ spec:
               app: api
       ports:
         - port: 6379
+# ─────────────────────────────────────────────────────────────
+# Egress allowlists
+# Engines and trace-service get NO egress allow here — default-deny
+# (plus DNS only) keeps untrusted JS from making outbound calls.
+# ─────────────────────────────────────────────────────────────
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: api-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: engine-v8
+        - podSelector:
+            matchLabels:
+              app: engine-hermes
+        - podSelector:
+            matchLabels:
+              app: engine-jsc
+        - podSelector:
+            matchLabels:
+              app: engine-spidermonkey
+        - podSelector:
+            matchLabels:
+              app: trace-service
+      ports:
+        - port: 8080
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - port: 6379
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: frontend-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: frontend
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: api
+        - podSelector:
+            matchLabels:
+              app: trace-service
+      ports:
+        - port: 8080

--- a/infra/k8s/base/trace-service.yaml
+++ b/infra/k8s/base/trace-service.yaml
@@ -33,6 +33,18 @@ spec:
               value: "warn"
           ports:
             - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
- networkpolicy: namespace default-deny (ingress+egress) with additive allowlists. Engines and trace-service get no egress allow (DNS only) so untrusted JS cannot make outbound calls. Add trace-service + frontend ingress policies and api/frontend egress.
- trace-service: add liveness/readiness probes on /healthz.
- middleware: track jslab-security-headers in repo (was a dangling ingress reference applied out-of-band); wire into base kustomization (prod only).
- deploy-infra.yml: drop hardcoded root@IP; use SSH_HOST/USER/PORT secrets plus host-key fingerprint verification (matches reusable workflow).
- infra/README.md: document out-of-band TLS secrets, netpol model, deploy.