### PR TITLE
ci: keep deploy SSH alive during rollout; trace-service typecheck-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
           - { name: engine-hermes,        dir: apps/engine-hermes,        typecheck: "npm run lint",  test: "" }
           - { name: engine-jsc,           dir: apps/engine-jsc,           typecheck: "npm run lint",  test: "" }
           - { name: engine-spidermonkey,  dir: apps/engine-spidermonkey,  typecheck: "npm run lint",  test: "" }
-          - { name: trace-service,        dir: apps/trace-service,        typecheck: "npm run typecheck", test: "npm test" }
+          # trace-service test sources are not committed (only gitignored dist/
+          # build output + the engine262 submodule), so `npm test` finds nothing
+          # in a clean checkout. Typecheck only until the suite is committed.
+          - { name: trace-service,        dir: apps/trace-service,        typecheck: "npm run typecheck", test: "" }
           - { name: frontend,             dir: apps/frontend/src,         typecheck: "npx --no-install tsc --noEmit -p tsconfig.json", test: "npm test" }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -77,6 +77,8 @@ jobs:
             -o BatchMode=yes \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
             -p "${SSH_PORT}" \
             "${SSH_USER}@${SSH_HOST}" <<'EOSSH'
           set -euo pipefail

--- a/.github/workflows/reusable-deploy-service-vps.yml
+++ b/.github/workflows/reusable-deploy-service-vps.yml
@@ -190,10 +190,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          # ServerAliveInterval keeps the session alive while `rollout status`
+          # waits silently (no output for minutes), so the VPS sshd does not drop
+          # the connection as idle and fail the step before the rollout finishes.
           ssh -i ~/.ssh/id_deploy \
             -o BatchMode=yes \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=20 \
             -p "${SSH_PORT}" \
             "${SSH_USER}@${SSH_HOST}" \
             "kubectl apply -f - && kubectl -n \"${NAMESPACE}\" rollout status \"deployment/${DEPLOYMENT_NAME}\" --timeout=10m" \


### PR DESCRIPTION
## What

Two CI fixes surfaced by the previous push to main:

1. **Deploy SSH idle-timeout** — `deploy-engine-v8/hermes` (and the rest) reported failure even though the new pods became **Ready** and are serving in prod. Root cause: the deploy step runs `kubectl rollout status` over SSH, which prints nothing for minutes while the old pod drains; the VPS sshd dropped the idle session at ~5m (exit 255). Added `ServerAliveInterval=30` / `ServerAliveCountMax=20` (≈10m tolerance, matching `--timeout=10m`) to the deploy SSH in both `reusable-deploy-service-vps.yml` and `deploy-infra.yml`.
2. **trace-service test step** — trace-service has no committed test sources (only gitignored `dist/` + the `engine262` submodule), so `npm test` exits 1 with "No test files found" in a clean checkout. CI now runs typecheck only for it until a real suite is committed.

## Verified

Prod confirmed healthy end-to-end **after** the engine rollouts (egress lockdown + concurrency/heap caps live):
- `POST /api/run` v8 `print(1+1)` → `2`
- hermes / jsc / sm all return output
- frontend `/` → 200

## Notes / follow-ups (not in this PR)
- The 4 engines redeploying simultaneously briefly doubles pods on the VPS (oversubscription) — consider staggering or right-sizing engine resources.
- trace-service needs its real test suite committed (currently only build artifacts are tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)