### PR TITLE
infra: Recreate rollout for engines + trace (fix stuck-termination deploy timeouts)

### DIFF
--- a/infra/k8s/base/engine-hermes.yaml
+++ b/infra/k8s/base/engine-hermes.yaml
@@ -6,6 +6,12 @@ metadata:
     app: engine-hermes
 spec:
   replicas: 1
+  # Single replica on a resource-tight node: recreate (no surge pod) so a
+  # rollout never needs 2x capacity. Avoids old pods getting stuck terminating
+  # when several engines roll at once. Trade-off: a few seconds of downtime
+  # for this engine during its own deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: engine-hermes
@@ -14,6 +20,7 @@ spec:
       labels:
         app: engine-hermes
     spec:
+      terminationGracePeriodSeconds: 15
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/infra/k8s/base/engine-jsc.yaml
+++ b/infra/k8s/base/engine-jsc.yaml
@@ -6,6 +6,12 @@ metadata:
     app: engine-jsc
 spec:
   replicas: 1
+  # Single replica on a resource-tight node: recreate (no surge pod) so a
+  # rollout never needs 2x capacity. Avoids old pods getting stuck terminating
+  # when several engines roll at once. Trade-off: a few seconds of downtime
+  # for this engine during its own deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: engine-jsc
@@ -14,6 +20,7 @@ spec:
       labels:
         app: engine-jsc
     spec:
+      terminationGracePeriodSeconds: 15
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/infra/k8s/base/engine-spidermonkey.yaml
+++ b/infra/k8s/base/engine-spidermonkey.yaml
@@ -6,6 +6,12 @@ metadata:
     app: engine-spidermonkey
 spec:
   replicas: 1
+  # Single replica on a resource-tight node: recreate (no surge pod) so a
+  # rollout never needs 2x capacity. Avoids old pods getting stuck terminating
+  # when several engines roll at once. Trade-off: a few seconds of downtime
+  # for this engine during its own deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: engine-spidermonkey
@@ -14,6 +20,7 @@ spec:
       labels:
         app: engine-spidermonkey
     spec:
+      terminationGracePeriodSeconds: 15
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/infra/k8s/base/engine-v8.yaml
+++ b/infra/k8s/base/engine-v8.yaml
@@ -6,6 +6,12 @@ metadata:
     app: engine-v8
 spec:
   replicas: 1
+  # Single replica on a resource-tight node: recreate (no surge pod) so a
+  # rollout never needs 2x capacity. Avoids old pods getting stuck terminating
+  # when several engines roll at once. Trade-off: a few seconds of downtime
+  # for this engine during its own deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: engine-v8
@@ -14,6 +20,7 @@ spec:
       labels:
         app: engine-v8
     spec:
+      terminationGracePeriodSeconds: 15
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/infra/k8s/base/trace-service.yaml
+++ b/infra/k8s/base/trace-service.yaml
@@ -6,6 +6,12 @@ metadata:
     app: trace-service
 spec:
   replicas: 1
+  # Single replica on a resource-tight node: recreate (no surge pod) so a
+  # rollout never needs 2x capacity. Avoids the pod getting stuck terminating
+  # when several services roll at once. Trade-off: a few seconds of downtime
+  # during its own deploy.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: trace-service
@@ -14,6 +20,7 @@ spec:
       labels:
         app: trace-service
     spec:
+      terminationGracePeriodSeconds: 15
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Problem
After the SSH-keepalive fix (#18), deploys stopped dying at ~5m but now fail at exactly 10m with `error: timed out waiting for the condition`, stuck on `1 old replica pending termination`.

Root cause: the #18 merge touched the shared reusable workflow → all 4 engine deploys + trace ran **simultaneously**. Default RollingUpdate spawns a surge pod, so the single VPS node transiently carries ~8 engine pods, the kubelet starves, and old pods get stuck Terminating → rollout never converges.

Prod itself stayed healthy throughout (all engines + frontend return 200); only the deploy **jobs** went red.

## Fix
`strategy: Recreate` + `terminationGracePeriodSeconds: 15` on the four engines + trace-service. With `replicas: 1`, Recreate terminates old → creates new (no surge, no 2x capacity), so rollouts converge even when several roll at once. Cost: a few seconds of single-engine downtime during its own deploy — acceptable for a playground, and far better than a 10m hung rollout.

api/frontend keep default RollingUpdate (lighter, deploy cleanly).

## Validated
- `kustomize build` base/prod/dev + all per-service overlays OK
- `type: Recreate` present on all 5 deployments

## Follow-up (not here)
Right-size engine CPU/mem requests, or serialize deploys via a shared concurrency group, to remove the underlying node-capacity fragility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)