### PR TITLE
fix(engines,api): backpressure 429 passthrough; correct jsc execution note

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -193,6 +193,22 @@ app.post("/api/run", async (req, reply) => {
       req.log.error({ engineUrl, status: engineRes.statusCode, sample: engineText.slice(0, 500) }, msg);
     }
 
+    // Engine signals backpressure (its per-pod concurrency cap) with 429.
+    // Propagate it verbatim with Retry-After so clients can back off, instead
+    // of letting the 5xx branch below collapse it into a generic 502.
+    if (engineRes.statusCode === 429) {
+      const retryAfter = engineRes.headers["retry-after"];
+      if (retryAfter) reply.header("retry-after", String(retryAfter));
+      let payload: unknown;
+      try {
+        payload = JSON.parse(engineText);
+      } catch {
+        payload = { ok: false, error: "engine busy" };
+      }
+      reply.code(429).send(payload);
+      return;
+    }
+
     // 5xx from the engine => treat as Bad Gateway
     if (engineRes.statusCode >= 500) {
       reply.code(502).send({ ok: false, error: `engine unavailable (${engineRes.statusCode})` });

--- a/apps/engine-hermes/src/server.ts
+++ b/apps/engine-hermes/src/server.ts
@@ -116,7 +116,10 @@ app.post("/run", async (req, reply) => {
   const flags = sanitizeFlags(parsed.options?.flags || []);
 
   if (inFlight >= config.MAX_CONCURRENCY) {
-    reply.code(503).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
+    // 429 (not 503): the api gateway maps engine 5xx to a generic 502, which
+    // would hide the backpressure signal and drop Retry-After. 429 is passed
+    // through so clients can back off and retry.
+    reply.code(429).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
     return;
   }
   inFlight++;

--- a/apps/engine-jsc/src/server.ts
+++ b/apps/engine-jsc/src/server.ts
@@ -131,7 +131,10 @@ app.post("/run", async (req, reply) => {
   const flags = sanitizeFlags(parsed.options?.flags || []);
 
   if (inFlight >= config.MAX_CONCURRENCY) {
-    reply.code(503).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
+    // 429 (not 503): the api gateway maps engine 5xx to a generic 502, which
+    // would hide the backpressure signal and drop Retry-After. 429 is passed
+    // through so clients can back off and retry.
+    reply.code(429).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
     return;
   }
   inFlight++;
@@ -142,6 +145,12 @@ app.post("/run", async (req, reply) => {
     const scriptPath = path.join(tmpDir, "snippet.js");
     await fs.writeFile(scriptPath, parsed.sourceText, "utf8");
 
+    // NOTE: jsc EXECUTES the script (the -d flag dumps bytecode but the file
+    // still runs), unlike sm/hermes which only compile + disassemble. jsc has
+    // no portable per-process heap cap (cf. d8's --max-old-space-size), so a
+    // single greedy script is bounded only by the concurrency gate + the pod
+    // memory limit. A JSC_ heap option could tighten this, but needs testing
+    // against the binary first.
     const result = await runCommand(config.JSCSHELL_PATH, [BYTECODE_FLAG, ...flags, scriptPath], { timeoutMs });
 
     if (result.timedOut) {

--- a/apps/engine-spidermonkey/src/server.ts
+++ b/apps/engine-spidermonkey/src/server.ts
@@ -144,7 +144,10 @@ app.post("/run", async (req, reply) => {
   const flags = sanitizeFlags(parsed.options?.flags || []);
 
   if (inFlight >= config.MAX_CONCURRENCY) {
-    reply.code(503).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
+    // 429 (not 503): the api gateway maps engine 5xx to a generic 502, which
+    // would hide the backpressure signal and drop Retry-After. 429 is passed
+    // through so clients can back off and retry.
+    reply.code(429).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
     return;
   }
   inFlight++;

--- a/apps/engine-v8/src/server.ts
+++ b/apps/engine-v8/src/server.ts
@@ -175,7 +175,10 @@ app.post("/run", async (req, reply) => {
   const flags = sanitizeFlags(parsed.options?.flags || []);
 
   if (inFlight >= config.MAX_CONCURRENCY) {
-    reply.code(503).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
+    // 429 (not 503): the api gateway maps engine 5xx to a generic 502, which
+    // would hide the backpressure signal and drop Retry-After. 429 is passed
+    // through so clients can back off and retry.
+    reply.code(429).header("Retry-After", "1").send({ ok: false, error: "engine busy" });
     return;
   }
   inFlight++;


### PR DESCRIPTION
Patches the two defects found in the earlier self-review.

## Defect 2 — engine `503` collapsed to `502`, lost `Retry-After`
The api maps any engine status `>= 500` to a generic `502 engine unavailable` **before** parsing the body. The concurrency gate returned `503`, so the "engine busy" backpressure signal and `Retry-After` were dropped.

- Engines (×4): gate now returns **`429`** (Too Many Requests) instead of `503`.
- api: explicit `429` passthrough — forwards `429` + `Retry-After` verbatim, before the 5xx→502 branch.

## Defect 1 — inaccurate "jsc only compiles" claim
jsc **executes** the script (`-d` dumps bytecode but the file still runs) — verified live (`print(6*7)` → `42`). sm/hermes only compile. jsc has no portable per-process heap cap (unlike d8's `--max-old-space-size`), so it is bounded only by the concurrency gate + pod memory limit. Documented accurately in code; a `JSC_` heap option is noted as a tested follow-up (not added blind to avoid breaking the binary).

## Validated
- `npm run lint` (tsc --noEmit) green for api + all 4 engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)