### PR TITLE
fix(repo): drop the blame-ignore entry the squash merge orphaned

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,5 +14,8 @@
 #      (the `history` job) fails if a listed SHA is not an ancestor of the
 #      branch, so a squash that orphans one is loud rather than silent.
 
-# style(repo): format the tree with Prettier and group imports
-82f8986bea2c3e3baf0ee8f9b44d6abdb57facb8
+# Nothing is listed yet. The whole-tree reformat that adopted Prettier was
+# squash-merged in #46, which replaced its SHA with one that also carries every
+# behavioural change in that PR — blame-ignoring that commit would hide real
+# authorship, so the reformat stays un-ignored. Rule 2 above exists because of
+# exactly this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,10 +137,15 @@ Two conventions worth knowing:
 a framework boundary is sometimes the honest type. Warnings do not fail CI. They
 are meant to be visible, so please don't add new ones without cause.
 
-Formatting the whole tree at once made one commit that touches almost every
-file. It is listed in `.git-blame-ignore-revs`; run
-`git config blame.ignoreRevsFile .git-blame-ignore-revs` once and `git blame`
-will skip past it. (GitHub's blame view does this automatically.)
+A whole-tree reformat makes one commit that touches almost every file, and
+`git blame` should skip past it: list it in `.git-blame-ignore-revs` and run
+`git config blame.ignoreRevsFile .git-blame-ignore-revs` once. (GitHub's blame
+view reads the file automatically.)
+
+The file is currently empty of entries. The reformat that adopted Prettier was
+squash-merged, so its SHA no longer exists and the only commit that carries
+those changes also carries behavioural ones — ignoring it would misattribute
+real edits, so that reformat stays un-ignored.
 
 That file only works if the SHAs in it survive the merge, and a squash merge
 mints new ones. A pure-formatting commit therefore has to reach `main` either


### PR DESCRIPTION
`main` is red: the `history` job fails because `.git-blame-ignore-revs` names `82f8986`, the formatting commit from #46. That PR was squash-merged, which minted a new SHA and orphaned the old one, so the guard added in the same PR fires — as designed.

Because `quality-gate` aggregates `history`, every PR to `main` is blocked until this lands.

The entry cannot simply be repointed: the squash commit `ebdd1cd` carries the reformat *and* every behavioural change in #46, so blame-ignoring it would misattribute real edits. The entry is removed instead, the file and its CI guard stay for future formatting commits, and CONTRIBUTING now says the reformat is un-ignored and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)