### PR TITLE
fix(api): name the budget behind X-RateLimit-* headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,13 @@ browsable rendering at `/api/docs`.
   key raises general and trace to its own quota (240/min), while the heavy
   bucket stays separately capped (60/min). 429 responses carry `Retry-After`
   and `meta.retryAfter`.
+- Every response — success included, not just 429 — carries `X-RateLimit-Limit`,
+  `X-RateLimit-Remaining`, and `X-RateLimit-Reset` for whichever budget was
+  checked, plus `X-RateLimit-Bucket` naming it (`general`, `heavy`, `trace`,
+  or their `key-*` counterparts for an API key). A request can spend from more
+  than one budget (e.g. general then heavy on a cache miss); the headers
+  describe the last one checked, which is the tightest bound on the caller's
+  next request.
 - Cache: Redis hash of engine+source+normalized flags+timeout bucket, TTL `CACHE_TTL_SECONDS` (default 600s); deterministic failures get the shorter `NEGATIVE_CACHE_TTL_SECONDS` (default 30s).
 
 ### Quick curl example

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -130,6 +130,11 @@ describe("gateway routes", () => {
     expect(res.statusCode).toBe(429);
     expect(res.headers["retry-after"]).toBeDefined();
     expect(res.json().meta.retryAfter).toBeGreaterThan(0);
+    // The 429 and a successful response draw from the same enforceLimit(), so
+    // their X-RateLimit-* headers describe the same budget the same way.
+    expect(res.headers["x-ratelimit-bucket"]).toBe("general");
+    expect(res.headers["x-ratelimit-limit"]).toBe("0");
+    expect(res.headers["x-ratelimit-remaining"]).toBe("0");
   });
 
   it("answers 401 for a key that is not on file", async () => {
@@ -169,6 +174,10 @@ describe("gateway routes", () => {
     // itself the proof that the cache short-circuited the run.
     expect(res.json().stdout).toBe("cached output");
     expect(res.json().meta.cacheHit).toBe(true);
+    // A cache hit only ever spends the general budget — the heavy one is for
+    // actually spawning an engine — so its headers are the ones on the reply.
+    expect(res.headers["x-ratelimit-bucket"]).toBe("general");
+    expect(res.headers["x-ratelimit-limit"]).toBe(String(config.RATE_LIMIT_PER_MIN));
   });
 
   it("turns an unreachable engine into a 502, not a crash", async () => {

--- a/apps/api/src/app.upstream.test.ts
+++ b/apps/api/src/app.upstream.test.ts
@@ -81,6 +81,38 @@ describe("proxying a run to its engine", () => {
     expect(typeof body.meta.durationMs).toBe("number");
   });
 
+  it("carries the heavy budget's X-RateLimit-* headers on a run that actually spawns an engine", async () => {
+    const { app, config } = makeApp();
+    open.push(app);
+    upstream.reply(ORIGIN, "/run", 200, { ok: true, stdout: "2", stderr: "", artifacts: [] });
+
+    const res = await run(app);
+
+    expect(res.statusCode).toBe(200);
+    // Spawning an engine spends the heavy budget after the general one, so
+    // its headers are the ones left on the reply — not the general bucket's.
+    expect(res.headers["x-ratelimit-bucket"]).toBe("heavy");
+    expect(res.headers["x-ratelimit-limit"]).toBe(String(config.RATE_LIMIT_HEAVY_PER_MIN));
+    expect(res.headers["x-ratelimit-remaining"]).toBe(String(config.RATE_LIMIT_HEAVY_PER_MIN - 1));
+  });
+
+  it("reports the same heavy-budget numbers on a successful run and the 429 that follows once it is exhausted", async () => {
+    const { app } = makeApp({ RATE_LIMIT_HEAVY_PER_MIN: "1" });
+    open.push(app);
+    upstream.reply(ORIGIN, "/run", 200, { ok: true, stdout: "2", stderr: "", artifacts: [] });
+
+    const ok = await run(app);
+    expect(ok.statusCode).toBe(200);
+    expect(ok.headers["x-ratelimit-bucket"]).toBe("heavy");
+    expect(ok.headers["x-ratelimit-remaining"]).toBe("0");
+
+    const limited = await run(app, { sourceText: "2+2" }); // different source: cache miss again, spends heavy again
+    expect(limited.statusCode).toBe(429);
+    expect(limited.headers["x-ratelimit-bucket"]).toBe("heavy");
+    expect(limited.headers["x-ratelimit-limit"]).toBe("1");
+    expect(limited.headers["x-ratelimit-remaining"]).toBe("0");
+  });
+
   it("passes an engine 429 through with its Retry-After", async () => {
     const { app } = makeApp();
     open.push(app);

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,5 +1,17 @@
 import { ENGINE_KINDS } from "@jslab/engine-runtime";
 
+/**
+ * Every route that spends from a rate-limit budget (see rateLimit.ts) sets
+ * these on its reply whether or not the request was limited, so they belong
+ * on every 2xx/429/5xx response a budget check precedes — not just 429.
+ */
+const RATE_LIMIT_RESPONSE_HEADERS = {
+  "X-RateLimit-Limit": { $ref: "#/components/headers/RateLimitLimit" },
+  "X-RateLimit-Remaining": { $ref: "#/components/headers/RateLimitRemaining" },
+  "X-RateLimit-Reset": { $ref: "#/components/headers/RateLimitReset" },
+  "X-RateLimit-Bucket": { $ref: "#/components/headers/RateLimitBucket" },
+} as const;
+
 export const openapiDoc = {
   openapi: "3.0.3",
   info: {
@@ -17,6 +29,29 @@ export const openapiDoc = {
     securitySchemes: {
       ApiKeyHeader: { type: "apiKey", in: "header", name: "x-api-key" },
       BearerAuth: { type: "http", scheme: "bearer" },
+    },
+    headers: {
+      // A request can spend from more than one budget (e.g. general then
+      // heavy); these four describe whichever one was checked last, which is
+      // the tightest bound on the caller's *next* request — not necessarily
+      // the first bucket the route touches.
+      RateLimitLimit: {
+        description: "Ceiling for the budget named in X-RateLimit-Bucket.",
+        schema: { type: "integer" },
+      },
+      RateLimitRemaining: {
+        description: "Requests left in that budget's current window.",
+        schema: { type: "integer" },
+      },
+      RateLimitReset: {
+        description: "Unix timestamp (seconds) when that budget's window resets.",
+        schema: { type: "integer" },
+      },
+      RateLimitBucket: {
+        description:
+          "Which budget the other three X-RateLimit-* headers describe, e.g. general, heavy, trace, key-general, key-heavy, key-trace, or key-issue.",
+        schema: { type: "string" },
+      },
     },
     schemas: {
       KeyResponse: {
@@ -255,6 +290,7 @@ export const openapiDoc = {
         responses: {
           "201": {
             description: "key issued",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/KeyResponse" } },
             },
@@ -267,12 +303,14 @@ export const openapiDoc = {
           },
           "429": {
             description: "issuance rate limited, or too many live keys for this address",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
           },
           "503": {
             description: "could not issue key",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
@@ -382,6 +420,7 @@ export const openapiDoc = {
         responses: {
           "200": {
             description: "ok",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ApiResponse" } },
             },
@@ -394,18 +433,21 @@ export const openapiDoc = {
           },
           "429": {
             description: "rate limited",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
           },
           "502": {
             description: "engine error",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
           },
           "504": {
             description: "engine timeout",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
@@ -425,6 +467,7 @@ export const openapiDoc = {
         responses: {
           "200": {
             description: "trace executed",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/TraceExecuteResponse" } },
             },
@@ -437,12 +480,14 @@ export const openapiDoc = {
           },
           "429": {
             description: "rate limited",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
           },
           "502": {
             description: "trace service unavailable",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
@@ -464,6 +509,7 @@ export const openapiDoc = {
         responses: {
           "200": {
             description: "trace executed",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/TraceExecuteResponse" } },
             },
@@ -476,12 +522,14 @@ export const openapiDoc = {
           },
           "429": {
             description: "rate limited",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },
           },
           "502": {
             description: "trace service unavailable",
+            headers: RATE_LIMIT_RESPONSE_HEADERS,
             content: {
               "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } },
             },

--- a/apps/api/src/rateLimit.test.ts
+++ b/apps/api/src/rateLimit.test.ts
@@ -47,6 +47,7 @@ describe("enforceLimit", () => {
     expect(headers["X-RateLimit-Limit"]).toBe("3");
     expect(headers["X-RateLimit-Remaining"]).toBe("2");
     expect(Number(headers["X-RateLimit-Reset"])).toBeGreaterThan(Date.now() / 1000);
+    expect(headers["X-RateLimit-Bucket"]).toBe("general");
     expect(headers["Retry-After"]).toBeUndefined();
 
     await enforceLimit(redis.client, "ip", "general", 3, 60, reply);
@@ -75,6 +76,19 @@ describe("enforceLimit", () => {
     expect((await enforceLimit(redis.client, "ip-a", "heavy", 1, 60, reply)).limited).toBe(false);
     expect((await enforceLimit(redis.client, "ip-b", "general", 1, 60, reply)).limited).toBe(false);
     expect((await enforceLimit(redis.client, "ip-a", "general", 1, 60, reply)).limited).toBe(true);
+  });
+
+  it("names the bucket its headers describe, so a later check's headers don't get mistaken for an earlier one's", async () => {
+    const redis = createFakeRedis();
+    const { reply, headers } = fakeReply();
+
+    await enforceLimit(redis.client, "ip", "general", 60, 60, reply);
+    expect(headers["X-RateLimit-Bucket"]).toBe("general");
+    expect(headers["X-RateLimit-Limit"]).toBe("60");
+
+    await enforceLimit(redis.client, "ip", "heavy", 20, 60, reply);
+    expect(headers["X-RateLimit-Bucket"]).toBe("heavy");
+    expect(headers["X-RateLimit-Limit"]).toBe("20");
   });
 
   it("rejects everything when the limit is zero", async () => {

--- a/apps/api/src/rateLimit.ts
+++ b/apps/api/src/rateLimit.ts
@@ -58,7 +58,11 @@ async function take(
  * Sets X-RateLimit-* headers for THIS limit, so the advertised limit always
  * matches the check that actually applied. Callers layer limits explicitly:
  * check "general" for every request, and additionally "heavy" only for
- * requests that spawn an engine (cache misses, trace executions).
+ * requests that spawn an engine (cache misses, trace executions). Headers are
+ * set whether or not the request is limited, so a successful response is just
+ * as informative as a 429 — X-RateLimit-Bucket names which of the (possibly
+ * several) budgets checked for this request the three numbers describe, since
+ * a later check in the same request overwrites the earlier one's headers.
  *
  * Fails open: a Redis error logs and admits the request — the engines have
  * their own per-pod concurrency gates, and turning a Redis blip into a 500
@@ -93,6 +97,7 @@ export async function enforceLimit(
   reply.header("X-RateLimit-Limit", String(limit));
   reply.header("X-RateLimit-Remaining", String(remaining));
   reply.header("X-RateLimit-Reset", String(Math.floor(Date.now() / 1000) + ttl));
+  reply.header("X-RateLimit-Bucket", suffix);
   if (limited) {
     reply.header("Retry-After", String(ttl));
   }


### PR DESCRIPTION
X-RateLimit-Limit/-Remaining/-Reset were already set on every response, not just 429s, but a request that spends from more than one budget (general, then heavy on a cache miss) had the second enforceLimit() call silently overwrite the first's headers with no way to tell which budget the numbers described.

Add X-RateLimit-Bucket, cover the cache-hit-vs-engine-spawn bucket switch and success/429 consistency in tests, and document all four headers in the OpenAPI response headers and the README.

## What

<!-- One or two sentences. The PR title must read like a commit subject
     (type(scope): summary) — it becomes the commit on a squash merge. -->

## How to verify

<!-- The command or the page that shows it working. `npm test` in the touched
     package at minimum; e2e/README.md if the change is user-visible. -->

## Checklist

- [ ] Tests cover the change (or the PR explains why none are needed)
- [ ] `npm run check` is clean at the repo root
- [ ] Touched the engine262 submodule? The fork branch is pushed (the pre-push hook checks this)
