### PR TITLE
docs: note that release-pr workflow triggers come from the pr head

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -55,7 +55,11 @@ Because the PR is opened by the App and not by `GITHUB_TOKEN`, workflows run on
 it like on any other PR: `ci.yml` (the quality gate) and `e2e.yml`, which
 builds the whole compose stack to its production targets and runs the browser
 suite. The release PR is the one place the full stack is exercised before a
-version name is attached to it.
+version name is attached to it. One catch: a `pull_request` run reads the
+workflow files from the PR's **head**, and release-please only rebuilds its
+branch when a releasable commit lands — so a change to a workflow's triggers
+reaches an already-open release PR only after "Update branch" (or the next
+`feat`/`fix` on `main`).
 
 ### 3. Cutting the release — you
 


### PR DESCRIPTION
## What

<!-- One or two sentences. The PR title must read like a commit subject
     (type(scope): summary) — it becomes the commit on a squash merge. -->

## How to verify

<!-- The command or the page that shows it working. `npm test` in the touched
     package at minimum; e2e/README.md if the change is user-visible. -->

## Checklist

- [ ] Tests cover the change (or the PR explains why none are needed)
- [ ] `npm run check` is clean at the repo root
- [ ] Touched the engine262 submodule? The fork branch is pushed (the pre-push hook checks this)
