### PR TITLE
fix(shiki): disposed highlighter

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,6 +4,11 @@
 # then dies in actions/checkout with "upload-pack: not our ref <sha>".
 set -euo pipefail
 
+# git exports GIT_DIR to hooks — in a linked worktree the superproject's
+# absolute gitdir — which would make every `git -C` below query the
+# superproject instead of the submodule. Rediscover from cwd instead.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 fail=0
 
 while read -r _local_ref local_sha _remote_ref _remote_sha; do

--- a/apps/frontend/src/components/OutputsPanel/CodeBlockShiki.tsx
+++ b/apps/frontend/src/components/OutputsPanel/CodeBlockShiki.tsx
@@ -1,7 +1,7 @@
-import { CodeBlock, createShikiAdapter, Flex, Float, IconButton } from "@chakra-ui/react";
-import type { HighlighterGeneric } from "shiki";
+import { CodeBlock, Flex, Float, IconButton } from "@chakra-ui/react";
 
-import { getSourceHighlighter, MACHINE_CODE_LANG, THEME } from "@/lib/shiki";
+import { MACHINE_CODE_LANG } from "@/lib/shiki";
+import { sourceShikiAdapter } from "@/lib/shiki-adapter";
 
 import DefaultEmptyCodeBlockState, {
   type DefaultEmptyCodeBlockStateProps,
@@ -20,7 +20,7 @@ const CodeBlockShiki: React.FC<Props> = ({
 
   return (
     <Flex flex={1}>
-      <CodeBlock.AdapterProvider value={shikiAdapter}>
+      <CodeBlock.AdapterProvider value={sourceShikiAdapter}>
         <CodeBlock.Root code={code} language={MACHINE_CODE_LANG}>
           <CodeBlock.Content>
             <Float placement="top-end" offset="5" zIndex="1">
@@ -39,10 +39,5 @@ const CodeBlockShiki: React.FC<Props> = ({
     </Flex>
   );
 };
-
-const shikiAdapter = createShikiAdapter<HighlighterGeneric<never, never>>({
-  load: getSourceHighlighter,
-  theme: THEME,
-});
 
 export default CodeBlockShiki;

--- a/apps/frontend/src/components/Samples/SampleCard.tsx
+++ b/apps/frontend/src/components/Samples/SampleCard.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import { Box, Card, CodeBlock, createShikiAdapter, HStack, Stack } from "@chakra-ui/react";
+import { Box, Card, CodeBlock, HStack, Stack } from "@chakra-ui/react";
 import type { ReactNode } from "react";
-import type { HighlighterGeneric } from "shiki";
 
-import { getSourceHighlighter, SOURCE_LANG, THEME } from "@/lib/shiki";
-
-const CODE_ADAPTER = createShikiAdapter<HighlighterGeneric<never, never>>({
-  load: getSourceHighlighter,
-  theme: THEME,
-});
+import { SOURCE_LANG } from "@/lib/shiki";
+import { sourceShikiAdapter } from "@/lib/shiki-adapter";
 
 type Props = {
   id: string;
@@ -59,7 +54,7 @@ const SampleCard: React.FC<Props> = ({
             {actions && <HStack gap={1}>{actions}</HStack>}
           </HStack>
 
-          <CodeBlock.AdapterProvider value={CODE_ADAPTER}>
+          <CodeBlock.AdapterProvider value={sourceShikiAdapter}>
             <CodeBlock.Root
               code={snippet}
               language={SOURCE_LANG}

--- a/apps/frontend/src/lib/shiki-adapter.ts
+++ b/apps/frontend/src/lib/shiki-adapter.ts
@@ -1,0 +1,12 @@
+import { createShikiAdapter } from "@chakra-ui/react";
+import type { HighlighterGeneric } from "shiki";
+
+import { getSourceHighlighter, THEME } from "@/lib/shiki";
+
+export const sourceShikiAdapter = {
+  ...createShikiAdapter<HighlighterGeneric<never, never>>({
+    load: getSourceHighlighter,
+    theme: THEME,
+  }),
+  unloadContext: () => {},
+};


### PR DESCRIPTION
## What

<!-- One or two sentences. The PR title must read like a commit subject
     (type(scope): summary) — it becomes the commit on a squash merge. -->

## How to verify

<!-- The command or the page that shows it working. `npm test` in the touched
     package at minimum; e2e/README.md if the change is user-visible. -->

## Checklist

- [ ] Tests cover the change (or the PR explains why none are needed)
- [ ] `npm run check` is clean at the repo root
- [ ] Touched the engine262 submodule? The fork branch is pushed (the pre-push hook checks this)
