### PR TITLE
feat(playground): show the sandbox prelude output collapsed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ Each engine service (`apps/engine-*/src/server.ts`) is a thin `startEngineServer
 - Zod schema validates `{ sourceText, options: { flags?, timeoutMs? } }`
 - `sanitizeFlags()` filters client-supplied flags against the shared `flagCatalog`; rejected flags are reported back in `meta.droppedFlags`
 - Per-pod concurrency gate returns 429 + `Retry-After` when saturated
-- A temp dir gets the snippet plus each prelude script; `invoke()` receives their absolute paths as `preludePaths`, in load order
+- A temp dir gets the snippet plus each prelude script; `invoke()` receives their absolute paths as `preludePaths`, in load order. Whenever any prelude loads, the runtime appends a final `prelude-end.js` that prints a marker line, and `stdout` is returned from the line after it, so what the prelude itself emits (the lockdown shim's own bytecode under `--print-bytecode`, for one) never reaches the client
 - `child_process.spawn()` runs the binary with timeout; combined stdout+stderr capped at `MAX_OUTPUT_BYTES` (default 2 MB), truncation flagged in `meta.outputTruncated`
 - Returns `{ ok, stdout, stderr, artifacts: [], meta }`
 - `GET /healthz` reports `{ ok, engine, version }`; the version probe runs once at startup (never per request) and stays `null` for a binary with no way to say, such as jsc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ Each engine service (`apps/engine-*/src/server.ts`) is a thin `startEngineServer
 - Zod schema validates `{ sourceText, options: { flags?, timeoutMs? } }`
 - `sanitizeFlags()` filters client-supplied flags against the shared `flagCatalog`; rejected flags are reported back in `meta.droppedFlags`
 - Per-pod concurrency gate returns 429 + `Retry-After` when saturated
-- A temp dir gets the snippet plus each prelude script; `invoke()` receives their absolute paths as `preludePaths`, in load order. Whenever any prelude loads, the runtime appends a final `prelude-end.js` that prints a marker line, and `stdout` is returned from the line after it, so what the prelude itself emits (the lockdown shim's own bytecode under `--print-bytecode`, for one) never reaches the client
+- A temp dir gets the snippet plus each prelude script; `invoke()` receives their absolute paths as `preludePaths`, in load order. Whenever any prelude loads, the runtime appends a final `prelude-end.js` that prints a marker line; `stdout` is returned from the line after it and everything before it (the lockdown shim's own bytecode under `--print-bytecode`, for one) comes back as `meta.preludeStdout`, which the playground shows collapsed
 - `child_process.spawn()` runs the binary with timeout; combined stdout+stderr capped at `MAX_OUTPUT_BYTES` (default 2 MB), truncation flagged in `meta.outputTruncated`
 - Returns `{ ok, stdout, stderr, artifacts: [], meta }`
 - `GET /healthz` reports `{ ok, engine, version }`; the version probe runs once at startup (never per request) and stays `null` for a binary with no way to say, such as jsc

--- a/apps/frontend/src/app/_components/OutputPane.tsx
+++ b/apps/frontend/src/app/_components/OutputPane.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box } from "@chakra-ui/react";
+import { useState } from "react";
 
 import { useEngineVersion } from "@/components/EngineVersion/context";
 import { HighlightedCode } from "@/components/OutputsPanel/CodeBlock";
@@ -39,6 +40,15 @@ const OutputPane: React.FC = () => {
       />
 
       <Box css={styles.outputScroller}>
+        {status === RunStatus.running ? null : (
+          <PreludeSection
+            key={activeTab}
+            engine={activeTab}
+            prelude={result?.preludeStdout}
+            previousPrelude={previous?.preludeStdout}
+            showDiff={showDiff}
+          />
+        )}
         <HighlightedCode
           engineKey={activeTab}
           out={result?.stdout}
@@ -59,6 +69,51 @@ const OutputPane: React.FC = () => {
         durationMs={result?.ms}
         flagCount={flagsFor(activeTab).length}
       />
+    </>
+  );
+};
+
+type PreludeSectionProps = {
+  engine: EngineKey;
+  prelude?: string;
+  previousPrelude?: string;
+  showDiff: boolean;
+};
+
+export const PreludeSection: React.FC<PreludeSectionProps> = ({
+  engine,
+  prelude,
+  previousPrelude,
+  showDiff,
+}) => {
+  const [open, setOpen] = useState(false);
+  if (!prelude) return null;
+
+  const lines = prelude.split("\n").length;
+
+  return (
+    <>
+      <Box
+        as="button"
+        css={styles.preludeToggle}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span aria-hidden="true">{open ? "▾" : "▸"}</span>
+        <span>sandbox prelude</span>
+        <Box as="span" css={styles.preludeMeta}>
+          {lines} line{lines === 1 ? "" : "s"} · {open ? "shown" : "hidden"}
+        </Box>
+      </Box>
+      {open ? (
+        <HighlightedCode
+          engineKey={engine}
+          out={prelude}
+          prev={previousPrelude}
+          showDiff={showDiff}
+          EmptyCodeBlockState={() => <></>}
+        />
+      ) : null}
     </>
   );
 };

--- a/apps/frontend/src/app/_components/playground.styles.ts
+++ b/apps/frontend/src/app/_components/playground.styles.ts
@@ -115,6 +115,35 @@ export const engineNote: SystemStyleObject = {
   textWrap: "pretty",
 };
 
+export const preludeToggle: SystemStyleObject = {
+  flex: "0 0 auto",
+  display: "flex",
+  alignItems: "baseline",
+  gap: "10px",
+  width: "100%",
+  textAlign: "left",
+  cursor: "pointer",
+  py: "7px",
+  px: "clamp(10px, 1vw, 14px)",
+  borderBottomWidth: "1px",
+  borderBottomColor: "rule.row",
+  bg: "surface.band",
+  fontFamily: "mono",
+  fontSize: "11px",
+  letterSpacing: "0.1em",
+  textTransform: "uppercase",
+  color: "ink.label",
+  _hover: { color: "accent" },
+  _focusVisible: { outline: "2px solid", outlineColor: "accent", outlineOffset: "-2px" },
+};
+
+export const preludeMeta: SystemStyleObject = {
+  marginLeft: "auto",
+  letterSpacing: "0.06em",
+  textTransform: "none",
+  color: "ink.6",
+};
+
 export const outputFooter: SystemStyleObject = {
   flex: "0 0 auto",
   display: "flex",

--- a/apps/frontend/src/lib/api.test.ts
+++ b/apps/frontend/src/lib/api.test.ts
@@ -145,6 +145,27 @@ describe("runEngine", () => {
     expect(result.droppedFlags).toEqual(["--nope"]);
   });
 
+  it("carries the sandbox prelude output separately and drops it when empty", async () => {
+    mockFetch({
+      ok: true,
+      status: 200,
+      body: {
+        ok: true,
+        stdout: "snippet bytecode",
+        stderr: "",
+        meta: { durationMs: 3, cacheHit: false, preludeStdout: " lockdown bytecode \n" },
+      },
+    });
+    expect((await runEngine(EngineKey.v8, "1")).preludeStdout).toBe("lockdown bytecode");
+
+    mockFetch({
+      ok: true,
+      status: 200,
+      body: { ok: true, stdout: "x", stderr: "", meta: { durationMs: 3, preludeStdout: "" } },
+    });
+    expect((await runEngine(EngineKey.v8, "1")).preludeStdout).toBeUndefined();
+  });
+
   it("keeps engine stderr when the script itself failed (ok:true)", async () => {
     mockFetch({
       ok: true,

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -15,6 +15,8 @@ export interface RunResult {
   failure?: RunFailure;
   outputTruncated?: boolean;
   droppedFlags?: string[];
+  /** What the sandbox prelude printed before the snippet ran; shown collapsed. */
+  preludeStdout?: string;
 }
 
 export interface RunOptions {
@@ -55,6 +57,8 @@ export async function runEngine(
           (flag: unknown): flag is string => typeof flag === "string",
         )
       : undefined;
+    const preludeStdout =
+      typeof payload.meta?.preludeStdout === "string" ? payload.meta.preludeStdout.trim() : "";
 
     return {
       stdout: (payload.stdout ?? "").trim(),
@@ -63,6 +67,7 @@ export async function runEngine(
       cacheHit: payload.meta?.cacheHit === true,
       outputTruncated: payload.meta?.outputTruncated === true,
       droppedFlags: droppedFlags?.length ? droppedFlags : undefined,
+      preludeStdout: preludeStdout || undefined,
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/apps/frontend/src/lib/types/index.ts
+++ b/apps/frontend/src/lib/types/index.ts
@@ -43,7 +43,12 @@ export const flagsFor = (flags: EngineFlags, engine: EngineKey): string[] => fla
 export const flagCount = (flags: EngineFlags): number =>
   ENGINE_KEYS.reduce((total, engine) => total + (flags[engine]?.length ?? 0), 0);
 
-export type EngineResult = { stdout: string; stderr: string; ms?: number };
+export type EngineResult = {
+  stdout: string;
+  stderr: string;
+  ms?: number;
+  preludeStdout?: string;
+};
 
 export enum RunStatus {
   idle = "idle",

--- a/packages/engine-runtime/src/app.test.ts
+++ b/packages/engine-runtime/src/app.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { buildEngineApp, type EngineSpec } from "./app.js";
+import { buildEngineApp, type EngineSpec, PRELUDE_END_MARKER, stripPreludeOutput } from "./app.js";
 import { engineEnvBase } from "./config.js";
 
 /**
@@ -76,6 +76,39 @@ describe("buildEngineApp", () => {
   it("writes no lockdown shim for a compile-only engine", async () => {
     const body = (await run(makeApp(), { sourceText: "/* snippet */" })).json();
     expect(body.stdout).toBe("/* snippet */");
+  });
+
+  it("drops what the prelude printed and keeps the snippet's own output", async () => {
+    // The realm executes each file like d8 does; --print-bytecode-style noise
+    // from the lockdown shim lands before the marker, the snippet after it.
+    const EXEC_FILES =
+      'const fs = require("fs"), vm = require("vm");' +
+      'globalThis.print = (s) => process.stdout.write(String(s) + "\\n");' +
+      'for (const p of process.argv.slice(1)) vm.runInThisContext(fs.readFileSync(p, "utf8"), { filename: p });';
+    const app = makeApp({
+      blockedGlobals: ["read"],
+      prelude: [{ file: "noisy.js", contents: 'print("prelude noise");' }],
+      invoke: ({ scriptPath, preludePaths }) => ({
+        cmd: process.execPath,
+        args: ["-e", EXEC_FILES, ...preludePaths, scriptPath],
+      }),
+    });
+
+    const body = (await run(app, { sourceText: 'print("snippet output");' })).json();
+    expect(body.stdout).toBe("snippet output\n");
+    expect(body.stdout).not.toContain(PRELUDE_END_MARKER);
+  });
+
+  it("does not add the end marker when nothing loads ahead of the snippet", async () => {
+    let paths: string[] = [];
+    const app = makeApp({
+      invoke: ({ scriptPath, preludePaths }) => {
+        paths = preludePaths;
+        return { cmd: process.execPath, args: ["-e", CAT_FILES, ...preludePaths, scriptPath] };
+      },
+    });
+    await run(app, { sourceText: "1;" });
+    expect(paths).toEqual([]);
   });
 
   it("removes the temp dir once the run is over", async () => {
@@ -155,5 +188,20 @@ describe("buildEngineApp", () => {
     const documented = makeApp({ openapiTitle: "engine-test" });
     const res = await documented.inject({ method: "GET", url: "/openapi.json" });
     expect(res.json().info.title).toBe("engine-test");
+  });
+});
+
+describe("stripPreludeOutput", () => {
+  it("removes everything through the marker line", () => {
+    expect(stripPreludeOutput(`noise\n${PRELUDE_END_MARKER}\nkept\n`)).toBe("kept\n");
+  });
+
+  it("leaves output without a marker untouched", () => {
+    expect(stripPreludeOutput("plain\n")).toBe("plain\n");
+  });
+
+  it("ignores a marker that does not start a line", () => {
+    const out = `print("${PRELUDE_END_MARKER}\n");\n`;
+    expect(stripPreludeOutput(out)).toBe(out);
   });
 });

--- a/packages/engine-runtime/src/app.test.ts
+++ b/packages/engine-runtime/src/app.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { buildEngineApp, type EngineSpec, PRELUDE_END_MARKER, stripPreludeOutput } from "./app.js";
+import { buildEngineApp, type EngineSpec, PRELUDE_END_MARKER, splitPreludeOutput } from "./app.js";
 import { engineEnvBase } from "./config.js";
 
 /**
@@ -78,7 +78,7 @@ describe("buildEngineApp", () => {
     expect(body.stdout).toBe("/* snippet */");
   });
 
-  it("drops what the prelude printed and keeps the snippet's own output", async () => {
+  it("moves what the prelude printed into meta and keeps the snippet's own output", async () => {
     // The realm executes each file like d8 does; --print-bytecode-style noise
     // from the lockdown shim lands before the marker, the snippet after it.
     const EXEC_FILES =
@@ -96,7 +96,26 @@ describe("buildEngineApp", () => {
 
     const body = (await run(app, { sourceText: 'print("snippet output");' })).json();
     expect(body.stdout).toBe("snippet output\n");
-    expect(body.stdout).not.toContain(PRELUDE_END_MARKER);
+    expect(body.meta.preludeStdout).toBe("prelude noise\n");
+    expect(JSON.stringify(body)).not.toContain(PRELUDE_END_MARKER);
+  });
+
+  it("reports no prelude output when nothing was printed ahead of the marker", async () => {
+    const EXEC_FILES =
+      'const fs = require("fs"), vm = require("vm");' +
+      'globalThis.print = (s) => process.stdout.write(String(s) + "\\n");' +
+      'for (const p of process.argv.slice(1)) vm.runInThisContext(fs.readFileSync(p, "utf8"), { filename: p });';
+    const app = makeApp({
+      blockedGlobals: ["read"],
+      invoke: ({ scriptPath, preludePaths }) => ({
+        cmd: process.execPath,
+        args: ["-e", EXEC_FILES, ...preludePaths, scriptPath],
+      }),
+    });
+
+    const body = (await run(app, { sourceText: 'print("only");' })).json();
+    expect(body.stdout).toBe("only\n");
+    expect(body.meta.preludeStdout).toBe("");
   });
 
   it("does not add the end marker when nothing loads ahead of the snippet", async () => {
@@ -191,17 +210,20 @@ describe("buildEngineApp", () => {
   });
 });
 
-describe("stripPreludeOutput", () => {
-  it("removes everything through the marker line", () => {
-    expect(stripPreludeOutput(`noise\n${PRELUDE_END_MARKER}\nkept\n`)).toBe("kept\n");
+describe("splitPreludeOutput", () => {
+  it("splits at the marker line", () => {
+    expect(splitPreludeOutput(`noise\n${PRELUDE_END_MARKER}\nkept\n`)).toEqual({
+      stdout: "kept\n",
+      preludeStdout: "noise\n",
+    });
   });
 
   it("leaves output without a marker untouched", () => {
-    expect(stripPreludeOutput("plain\n")).toBe("plain\n");
+    expect(splitPreludeOutput("plain\n")).toEqual({ stdout: "plain\n" });
   });
 
   it("ignores a marker that does not start a line", () => {
     const out = `print("${PRELUDE_END_MARKER}\n");\n`;
-    expect(stripPreludeOutput(out)).toBe(out);
+    expect(splitPreludeOutput(out)).toEqual({ stdout: out });
   });
 });

--- a/packages/engine-runtime/src/app.ts
+++ b/packages/engine-runtime/src/app.ts
@@ -119,16 +119,29 @@ interface Workspace {
   dispose(): Promise<void>;
 }
 
+export const PRELUDE_END_MARKER = "@@jslab:prelude-end@@";
+
+const PRELUDE_END_SCRIPT: PreludeScript = {
+  file: "prelude-end.js",
+  contents: `try { print(${JSON.stringify(PRELUDE_END_MARKER)}); } catch (e) {}\n`,
+};
+
 /** The prelude a spec asks for, with the generated lockdown shim ahead of it. */
 function preludeScripts(spec: EngineSpec): readonly PreludeScript[] {
   const declared = spec.prelude ?? [];
-  if (!spec.blockedGlobals?.length) return declared;
   // Lockdown loads first so the snippet never observes a dangerous global, not
   // even transiently through another prelude script.
-  return [
-    { file: LOCKDOWN_SHIM_FILE, contents: buildLockdownShim(spec.blockedGlobals) },
-    ...declared,
-  ];
+  const scripts = spec.blockedGlobals?.length
+    ? [{ file: LOCKDOWN_SHIM_FILE, contents: buildLockdownShim(spec.blockedGlobals) }, ...declared]
+    : [...declared];
+  return scripts.length ? [...scripts, PRELUDE_END_SCRIPT] : scripts;
+}
+
+export function stripPreludeOutput(stdout: string): string {
+  const line = `${PRELUDE_END_MARKER}\n`;
+  const at = stdout.indexOf(line);
+  if (at === -1 || (at > 0 && stdout[at - 1] !== "\n")) return stdout;
+  return stdout.slice(at + line.length);
 }
 
 /** Temp dir holding the snippet plus its prelude, cleaned up by `dispose`. */
@@ -263,7 +276,7 @@ export function buildEngineApp(spec: EngineSpec): FastifyInstance {
       // so the gateway can size its cache guard against it.
       reply.send({
         ok: true,
-        stdout: result.stdout,
+        stdout: stripPreludeOutput(result.stdout),
         stderr: result.stderr,
         artifacts: [],
         meta: {

--- a/packages/engine-runtime/src/app.ts
+++ b/packages/engine-runtime/src/app.ts
@@ -137,11 +137,11 @@ function preludeScripts(spec: EngineSpec): readonly PreludeScript[] {
   return scripts.length ? [...scripts, PRELUDE_END_SCRIPT] : scripts;
 }
 
-export function stripPreludeOutput(stdout: string): string {
+export function splitPreludeOutput(stdout: string): { stdout: string; preludeStdout?: string } {
   const line = `${PRELUDE_END_MARKER}\n`;
   const at = stdout.indexOf(line);
-  if (at === -1 || (at > 0 && stdout[at - 1] !== "\n")) return stdout;
-  return stdout.slice(at + line.length);
+  if (at === -1 || (at > 0 && stdout[at - 1] !== "\n")) return { stdout };
+  return { stdout: stdout.slice(at + line.length), preludeStdout: stdout.slice(0, at) };
 }
 
 /** Temp dir holding the snippet plus its prelude, cleaned up by `dispose`. */
@@ -274,14 +274,16 @@ export function buildEngineApp(spec: EngineSpec): FastifyInstance {
       // fits and say so in meta. outputLimitBytes is the true ceiling for the
       // whole body: runCommand caps stdout + stderr *combined* at this value,
       // so the gateway can size its cache guard against it.
+      const output = splitPreludeOutput(result.stdout);
       reply.send({
         ok: true,
-        stdout: stripPreludeOutput(result.stdout),
+        stdout: output.stdout,
         stderr: result.stderr,
         artifacts: [],
         meta: {
           durationMs: Date.now() - start,
           engine,
+          ...(output.preludeStdout !== undefined ? { preludeStdout: output.preludeStdout } : {}),
           ...(result.outputTruncated
             ? { outputTruncated: true, outputLimitBytes: config.MAX_OUTPUT_BYTES }
             : {}),


### PR DESCRIPTION
Under `--print-bytecode` the V8 tab printed five `generated bytecode` blocks for a one-line snippet; four of them belonged to the sandbox lockdown shim the engine service loads ahead of the snippet.

- `engine-runtime`: whenever any prelude loads (the lockdown shim for d8 and jsc, the console shim for jsc), a final `prelude-end.js` prints a marker line. `stdout` is returned from the line after it, and everything before it comes back as `meta.preludeStdout`. Output without a marker is returned untouched; Hermes and SpiderMonkey have no preludes and are unaffected.
- `frontend`: the playground shows `preludeStdout` as a collapsed "sandbox prelude · N lines" row above the engine output; clicking it expands the prelude with the same highlighting and diff support. The snippet's own bytecode is what the pane opens on.

Verified on the dev stack: for `function f(x){ return x + 1 } f(41);` the pane shows the snippet's two blocks, and the collapsed row holds the 150-line prelude. For jsc one `End: undefined` line from `prelude-end.js` itself remains in stdout and the marker text shows up in the `-d` disassembly on stderr; that is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)